### PR TITLE
Feature/39 enable setting of location for a store

### DIFF
--- a/src/main/kotlin/hr/foi/pop/backend/controllers/StoreController.kt
+++ b/src/main/kotlin/hr/foi/pop/backend/controllers/StoreController.kt
@@ -4,6 +4,8 @@ import hr.foi.pop.backend.definitions.ApplicationErrorType
 import hr.foi.pop.backend.exceptions.BadRoleException
 import hr.foi.pop.backend.exceptions.InvalidStoreNameException
 import hr.foi.pop.backend.exceptions.UserHasStoreException
+import hr.foi.pop.backend.models.store.Store
+import hr.foi.pop.backend.models.store.StoreLocation
 import hr.foi.pop.backend.models.store.StoreMapper
 import hr.foi.pop.backend.request_bodies.CreateStoreRequestBody
 import hr.foi.pop.backend.responses.ErrorResponse
@@ -24,7 +26,13 @@ class StoreController {
     fun createStore(@RequestBody request: CreateStoreRequestBody): ResponseEntity<SuccessResponse> {
         val newStoreName = request.storeName!!
 
-        val newStore = storeService.createStore(newStoreName)
+        val newStore: Store = if (request.latitude == null && request.longitude == null) {
+            storeService.createStore(newStoreName)
+        } else {
+            val newLocation = StoreLocation(request.latitude, request.longitude)
+            storeService.createStore(newStoreName, newLocation)
+        }
+
         val newStoreDto = StoreMapper().mapDto(newStore)
 
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/kotlin/hr/foi/pop/backend/models/store/Store.kt
+++ b/src/main/kotlin/hr/foi/pop/backend/models/store/Store.kt
@@ -3,9 +3,13 @@ package hr.foi.pop.backend.models.store
 import hr.foi.pop.backend.models.event.Event
 import jakarta.persistence.*
 
+private const val FOI_LATITUDE = 46.307679
+private const val FOI_LONGITUDE = 16.338106
+
 @Entity
 @Table(name = "stores")
 class Store {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_store")
@@ -21,4 +25,9 @@ class Store {
     @Column
     var balance: Int = 0
 
+    @Column
+    var longitude: Double = FOI_LONGITUDE
+
+    @Column
+    var latitude: Double = FOI_LATITUDE
 }

--- a/src/main/kotlin/hr/foi/pop/backend/models/store/StoreLocation.kt
+++ b/src/main/kotlin/hr/foi/pop/backend/models/store/StoreLocation.kt
@@ -1,0 +1,3 @@
+package hr.foi.pop.backend.models.store
+
+data class StoreLocation(val latitude: Double?, val longitude: Double?)

--- a/src/main/kotlin/hr/foi/pop/backend/request_bodies/CreateStoreRequestBody.kt
+++ b/src/main/kotlin/hr/foi/pop/backend/request_bodies/CreateStoreRequestBody.kt
@@ -1,3 +1,7 @@
 package hr.foi.pop.backend.request_bodies
 
-data class CreateStoreRequestBody(val storeName: String?)
+data class CreateStoreRequestBody(
+    val storeName: String?,
+    val latitude: Double?,
+    val longitude: Double?
+)

--- a/src/main/kotlin/hr/foi/pop/backend/services/StoreService.kt
+++ b/src/main/kotlin/hr/foi/pop/backend/services/StoreService.kt
@@ -3,6 +3,7 @@ package hr.foi.pop.backend.services
 import hr.foi.pop.backend.definitions.ApplicationErrorType
 import hr.foi.pop.backend.exceptions.*
 import hr.foi.pop.backend.models.store.Store
+import hr.foi.pop.backend.models.store.StoreLocation
 import hr.foi.pop.backend.repositories.EventRepository
 import hr.foi.pop.backend.repositories.StoreRepository
 import hr.foi.pop.backend.repositories.UserRepository
@@ -24,7 +25,7 @@ class StoreService {
     @Autowired
     lateinit var userRepository: UserRepository
 
-    fun createStore(newStoreName: String): Store {
+    fun createStore(newStoreName: String, newStoreLocation: StoreLocation? = null): Store {
         ensureUserIsNotForbiddenToCreateStores()
         ensureStoreNameIsProper(newStoreName)
         ensureStoreNameIsUnique(newStoreName)
@@ -33,6 +34,11 @@ class StoreService {
             storeName = newStoreName
             event = eventRepository.getEventByIsActiveTrue()
             balance = 0
+        }
+
+        if (newStoreLocation?.longitude != null && newStoreLocation.latitude != null) {
+            newStore.longitude = newStoreLocation.longitude
+            newStore.latitude = newStoreLocation.latitude
         }
 
         return storeRepository.save(newStore)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -47,7 +47,9 @@ VALUES (3, 1, NULL, 'Catherine', 'Velasquez', 'cvelasquez@pop.app', 'cvelasquez'
        (1, 2, 3, 'Connor', 'Kaufman', 'ckaufman@pop.app', 'ckaufman',
         '$2a$10$FfiydZ0lGFvgs288gbAhmeOBaF9h.kfgjmtkJcowuWUTdLB1Tl4gG', CURRENT_TIMESTAMP(), 70, 0),
        (2, 2, 3, 'Haven', 'Arroyo', 'harroyo@pop.app', 'harroyo',
-        '$2a$10$FfiydZ0lGFvgs288gbAhmeOBaF9h.kfgjmtkJcowuWUTdLB1Tl4gG', CURRENT_TIMESTAMP(), 0, 0);
+        '$2a$10$FfiydZ0lGFvgs288gbAhmeOBaF9h.kfgjmtkJcowuWUTdLB1Tl4gG', CURRENT_TIMESTAMP(), 0, 0),
+       (2, 1, NULL, 'Ivan', 'Horvat', 'ihorvat@pop.app', 'ihorvat',
+        '$2a$10$FfiydZ0lGFvgs288gbAhmeOBaF9h.kfgjmtkJcowuWUTdLB1Tl4gG', CURRENT_TIMESTAMP(), 0, 1);
 
 INSERT INTO `popapp_db`.`products` (`stores_id_store`, `name`, `description`, `image`, `price`, `quantity`)
 VALUES (1, 'Product 1', 'Description 1', 'image1.jpg', 10, 100),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS `popapp_db`.`stores` (
     `events_id_event` INT NOT NULL,
     `store_name` VARCHAR(255) NOT NULL,
     `balance` INT NOT NULL DEFAULT 0,
+    `latitude` FLOAT NOT NULL DEFAULT 0.0,
+    `longitude` FLOAT NOT NULL DEFAULT 0.0,
     PRIMARY KEY (`id_store`),
     CONSTRAINT `fk_stores_events1`
       FOREIGN KEY (`events_id_event`)

--- a/src/test/kotlin/hr/foi/pop/backend/services/StoreServiceTest.kt
+++ b/src/test/kotlin/hr/foi/pop/backend/services/StoreServiceTest.kt
@@ -5,6 +5,7 @@ import hr.foi.pop.backend.exceptions.InvalidStoreNameException
 import hr.foi.pop.backend.exceptions.UsedStoreNameException
 import hr.foi.pop.backend.exceptions.UserHasStoreException
 import hr.foi.pop.backend.models.store.Store
+import hr.foi.pop.backend.models.store.StoreLocation
 import hr.foi.pop.backend.models.user.User
 import hr.foi.pop.backend.repositories.EventRepository
 import hr.foi.pop.backend.repositories.StoreRepository
@@ -71,6 +72,27 @@ class StoreServiceTest {
         Assertions.assertEquals(0, newStoreEntity.balance)
         Assertions.assertEquals(46.307679, newStoreEntity.latitude)
         Assertions.assertEquals(16.338106, newStoreEntity.longitude)
+    }
+
+    @Test
+    @WithMockUser(username = "StoreServiceTester", authorities = ["seller"])
+    fun givenStoreNameAndLocation_whenUserIsSeller_returnNewStoreEntityObjectWithCustomLocation() {
+        assertStoreDoesntExist(properAndUniqueStoreName)
+
+        val newStoreEntity: Store = storeService.createStore(
+            newStoreName = properAndUniqueStoreName,
+            newStoreLocation = StoreLocation(
+                latitude = 20.50123,
+                longitude = 10.35123
+            )
+        )
+
+        assertStoreHasCustomLocationCorrectlySet(newStoreEntity)
+    }
+
+    private fun assertStoreHasCustomLocationCorrectlySet(newStoreEntity: Store) {
+        Assertions.assertEquals(20.50123, newStoreEntity.latitude)
+        Assertions.assertEquals(10.35123, newStoreEntity.longitude)
     }
 
     @Test

--- a/src/test/kotlin/hr/foi/pop/backend/services/StoreServiceTest.kt
+++ b/src/test/kotlin/hr/foi/pop/backend/services/StoreServiceTest.kt
@@ -69,6 +69,8 @@ class StoreServiceTest {
         val currentEvent = eventRepository.getEventByIsActiveTrue()
         Assertions.assertEquals(currentEvent.id, newStoreEntity.event.id)
         Assertions.assertEquals(0, newStoreEntity.balance)
+        Assertions.assertEquals(46.307679, newStoreEntity.latitude)
+        Assertions.assertEquals(16.338106, newStoreEntity.longitude)
     }
 
     @Test


### PR DESCRIPTION
Stores can now be created with latitude and longitude properties.
This allows for positioning of stores on the map, as needed for our laboratory exercise (read #39).

In case no location is sent, a default location is set on the geographical location of the FOI 1 building in Varaždin, Croatia.